### PR TITLE
updating environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ name: h-baselines
 dependencies:
     - python==3.6.8
     - numpy==1.16.0
+    - pip
     - pip:
         - redis==2.10.6
         - gym==0.14.0


### PR DESCRIPTION
Without this line anaconda spams the powershell with warnings when creating the environment.
"Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you."
